### PR TITLE
feat: resolve most platforms with postfetch, Cobalt as fallback

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -17,6 +17,7 @@
 		"@grammyjs/auto-retry": "npm:@grammyjs/auto-retry@2.0.2",
 		"@grammyjs/i18n": "npm:@grammyjs/i18n@0.5.1",
 		"@grammyjs/runner": "npm:@grammyjs/runner@2.0.3",
+		"@postfetch/core": "jsr:@postfetch/core@^0.3.0",
 		"grammy": "npm:grammy@1.43.0",
 		"mongodb": "npm:mongodb@4.17.2"
 	}

--- a/deno.lock
+++ b/deno.lock
@@ -1,12 +1,18 @@
 {
   "version": "5",
   "specifiers": {
+    "jsr:@postfetch/core@0.3": "0.3.0",
     "npm:@biomejs/biome@1.9.4": "1.9.4",
     "npm:@grammyjs/auto-retry@2.0.2": "2.0.2_grammy@1.43.0",
     "npm:@grammyjs/i18n@0.5.1": "0.5.1",
     "npm:@grammyjs/runner@2.0.3": "2.0.3_grammy@1.43.0",
     "npm:grammy@1.43.0": "1.43.0",
     "npm:mongodb@4.17.2": "4.17.2"
+  },
+  "jsr": {
+    "@postfetch/core@0.3.0": {
+      "integrity": "3230261c9992c87f539eb8b0f60e5692b6adbdf895a1b84581c47fde3c019374"
+    }
   },
   "npm": {
     "@aws-crypto/sha256-browser@5.2.0": {
@@ -850,7 +856,8 @@
         "@smithy/service-error-classification",
         "@smithy/types",
         "tslib"
-      ]
+      ],
+      "deprecated": true
     },
     "@smithy/util-stream@4.5.25": {
       "integrity": "sha512-/PFpG4k8Ze8Ei+mMKj3oiPICYekthuzePZMgZbCqMiXIHHf4n2aZ4Ps0aSRShycFTGuj/J6XldmC0x0DwednIA==",
@@ -1079,6 +1086,7 @@
   },
   "workspace": {
     "dependencies": [
+      "jsr:@postfetch/core@0.3",
       "npm:@biomejs/biome@1.9.4",
       "npm:@grammyjs/auto-retry@2.0.2",
       "npm:@grammyjs/i18n@0.5.1",

--- a/src/services/download-media.ts
+++ b/src/services/download-media.ts
@@ -1,6 +1,7 @@
 import { InputFile } from "grammy";
 
 import { type DownloadMediaFile, downloadMedia } from "./cobalt.ts";
+import { downloadWithPostfetch } from "./postfetch.ts";
 
 export type DownloadedImage = DownloadMediaFile & {
 	path?: string;
@@ -54,17 +55,17 @@ export async function materializeImageFiles(
 export async function downloadMediaForUrl(
 	url: string,
 ): Promise<DownloadedMedia | null> {
-	const cobaltMedia = await downloadMedia(url);
-	if (cobaltMedia) {
-		console.info("[DownloadMedia] Downloaded media with Cobalt", {
+	const media =
+		(await downloadWithPostfetch(url)) ?? (await downloadMedia(url));
+	if (media) {
+		console.info("[DownloadMedia] Downloaded media", {
 			url,
-			mediaType: cobaltMedia.type,
-			mediaKind:
-				cobaltMedia.type === "single" ? cobaltMedia.mediaKind : "multiple",
+			mediaType: media.type,
+			mediaKind: media.type === "single" ? media.mediaKind : "multiple",
 		});
 
-		if (cobaltMedia.type === "multiple") {
-			const files = cobaltMedia.files
+		if (media.type === "multiple") {
+			const files = media.files
 				.filter(
 					(
 						file,
@@ -102,14 +103,14 @@ export async function downloadMediaForUrl(
 		}
 
 		return {
-			kind: cobaltMedia.mediaKind,
-			bytes: cobaltMedia.file.data,
-			extension: cobaltMedia.extension,
-			file: new InputFile(cobaltMedia.file.data, cobaltMedia.file.filename),
-			filename: cobaltMedia.file.filename,
+			kind: media.mediaKind,
+			bytes: media.file.data,
+			extension: media.extension,
+			file: new InputFile(media.file.data, media.file.filename),
+			filename: media.file.filename,
 		};
 	}
 
-	console.info("[DownloadMedia] Cobalt failed to download media", { url });
+	console.info("[DownloadMedia] Failed to download media", { url });
 	return null;
 }

--- a/src/services/postfetch.ts
+++ b/src/services/postfetch.ts
@@ -1,0 +1,86 @@
+import { type MediaItem, detect, download, postfetch } from "@postfetch/core";
+
+import type { DownloadMediaFile, DownloadMediaResult } from "./cobalt.ts";
+
+// Platforms postfetch resolves directly, no Cobalt server needed. YouTube is left
+// out on purpose: its CDN gates datacenter IPs (where the bot runs), so yt-dlp via
+// Cobalt stays the path for it. Everything here falls back to Cobalt on failure.
+const POSTFETCH_PLATFORMS = new Set([
+	"facebook",
+	"instagram",
+	"pinterest",
+	"reddit",
+	"soundcloud",
+	"tiktok",
+	"twitter",
+]);
+
+export async function downloadWithPostfetch(
+	url: string,
+): Promise<DownloadMediaResult | null> {
+	if (!isPostfetchPlatform(url)) {
+		return null;
+	}
+
+	try {
+		const result = await postfetch(url);
+		const files = await Promise.all(result.items.map(toDownloadMediaFile));
+		return bundle(files);
+	} catch (error) {
+		console.warn(
+			"[Postfetch] Failed to resolve media; falling back to Cobalt",
+			{
+				url,
+				error,
+			},
+		);
+		return null;
+	}
+}
+
+function isPostfetchPlatform(url: string): boolean {
+	try {
+		return POSTFETCH_PLATFORMS.has(detect(url));
+	} catch {
+		return false;
+	}
+}
+
+function bundle(files: DownloadMediaFile[]): DownloadMediaResult | null {
+	if (files.length === 0) {
+		return null;
+	}
+
+	if (files.length > 1) {
+		return { type: "multiple", files, mediaKind: "mixed" };
+	}
+
+	const [file] = files;
+	return {
+		type: "single",
+		file,
+		mediaKind: file.mediaKind,
+		extension: file.extension,
+	};
+}
+
+// postfetch resolves to URLs (and remuxes DASH/HLS at download time); download
+// returns the ready bytes, which map straight onto Cobalt's file shape.
+async function toDownloadMediaFile(
+	item: MediaItem,
+): Promise<DownloadMediaFile> {
+	const response = await download(item);
+	const data = new Uint8Array(await response.arrayBuffer());
+	return {
+		contentType: item.mime,
+		data,
+		extension: extensionOf(item.filename),
+		filename: item.filename,
+		mediaKind: item.kind,
+	};
+}
+
+function extensionOf(filename: string): string {
+	const extension = filename.split(".").at(-1);
+	return extension && extension !== filename ? extension.toLowerCase() : "bin";
+}


### PR DESCRIPTION
Adds [`@postfetch/core`](https://jsr.io/@postfetch/core) (JSR, **zero dependencies**) as the primary media resolver, with **Cobalt kept as the fallback** — no behaviour removed.

## What changes
`downloadMediaForUrl` now tries postfetch first and falls back to Cobalt on `null` or failure:

```ts
const media = (await downloadWithPostfetch(url)) ?? (await downloadMedia(url));
```

`downloadWithPostfetch` (new `src/services/postfetch.ts`) resolves **Instagram, TikTok, Facebook, X, Reddit, Pinterest and SoundCloud** directly and returns the existing `DownloadMediaResult` shape, so every downstream branch (media groups, collages, caching, guest queries) is untouched.

**YouTube is deliberately left to Cobalt/yt-dlp** — its CDN gates datacenter IPs (where the bot runs), so postfetch returns `null` for it and Cobalt handles it as before. Cobalt also covers anything postfetch can't resolve.

## Why
- postfetch resolves **logged out** and **remuxes DASH/HLS in-process** (Reddit audio, Pinterest idea pins, SoundCloud HLS) into a single MP4 — **no `ffmpeg`, no extra service**, no cookies.
- For the seven platforms above it removes the round-trip to the Cobalt server (and its cold starts), and is more robust on Instagram (the reel-resolves-to-cover failure mode).
- The Azure Cobalt proxy / yt-dlp path stays exactly as-is for YouTube and as a safety net.

## Footprint
Three files: `+ src/services/postfetch.ts`, a one-line change in `download-media.ts`, and the `@postfetch/core` entry in `deno.json`. `COBALT_*` env stays required (Cobalt is still used).

## Verification
`deno task verify` is green (biome + `deno check`). Resolved + downloaded real posts end-to-end through `downloadWithPostfetch`:

| Platform | Result |
| --- | --- |
| Reddit | image, 1.4 MB jpg |
| TikTok | video, 3.8 MB mp4 |
| X (Twitter) | video, 1.5 MB mp4 |
| Pinterest | video, 1.4 MB mp4 |
| SoundCloud | audio, 3.3 MB mp3 |
| YouTube | `null` → falls back to Cobalt ✅ |

postfetch's resolvers and the DASH/HLS remuxing are themselves validated against `ffmpeg` in that project's CI.