### PR TITLE
✨ Post captions, chat settings and unavailability reasons

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -4,18 +4,19 @@
 		"dev": "deno run -A --env-file=.env --watch src/index.ts",
 		"warp": "docker build -t umm-warp warp && docker run -d --name umm-warp -p 1080:1080 umm-warp",
 		"dev:local": "bash scripts/dev-local.sh",
-		"check": "deno check src/index.ts src/migrations/add-chat-settings.ts",
+		"check": "deno check src/index.ts src/migrations/add-chat-settings.ts src/migrations/add-caption-settings.ts",
 		"test": "deno test -A test/",
 		"format": "deno run -A @biomejs/biome lint . --write; deno run -A @biomejs/biome format . --write",
-		"verify": "deno run -A @biomejs/biome check . && deno check src/index.ts src/migrations/add-chat-settings.ts",
-		"migrate:add-chat-settings": "deno run -A --env-file=.env src/migrations/add-chat-settings.ts"
+		"verify": "deno run -A @biomejs/biome check . && deno check src/index.ts src/migrations/add-chat-settings.ts src/migrations/add-caption-settings.ts",
+		"migrate:add-chat-settings": "deno run -A --env-file=.env src/migrations/add-chat-settings.ts",
+		"migrate:add-caption-settings": "deno run -A --env-file=.env src/migrations/add-caption-settings.ts"
 	},
 	"imports": {
 		"@biomejs/biome": "npm:@biomejs/biome@1.9.4",
 		"@grammyjs/auto-retry": "npm:@grammyjs/auto-retry@2.0.2",
 		"@grammyjs/i18n": "npm:@grammyjs/i18n@0.5.1",
 		"@grammyjs/runner": "npm:@grammyjs/runner@2.0.3",
-		"@postfetch/core": "jsr:@postfetch/core@^0.3.0",
+		"@postfetch/core": "jsr:@postfetch/core@^0.5.0",
 		"grammy": "npm:grammy@1.43.0",
 		"mongodb": "npm:mongodb@4.17.2"
 	}

--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@postfetch/core@0.3": "0.3.0",
+    "jsr:@postfetch/core@0.5": "0.5.0",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "npm:@biomejs/biome@1.9.4": "1.9.4",
@@ -12,8 +12,8 @@
     "npm:mongodb@4.17.2": "4.17.2"
   },
   "jsr": {
-    "@postfetch/core@0.3.0": {
-      "integrity": "3230261c9992c87f539eb8b0f60e5692b6adbdf895a1b84581c47fde3c019374"
+    "@postfetch/core@0.5.0": {
+      "integrity": "24b7d776199f39e1ffdaa8b7c744ac4c3c52b8c0624d49a22bdecbc7e9333e13"
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -1097,7 +1097,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@postfetch/core@0.3",
+      "jsr:@postfetch/core@0.5",
       "npm:@biomejs/biome@1.9.4",
       "npm:@grammyjs/auto-retry@2.0.2",
       "npm:@grammyjs/i18n@0.5.1",

--- a/src/config/bot.ts
+++ b/src/config/bot.ts
@@ -77,6 +77,12 @@ export async function startBot(database: Database) {
 	extendContext(bot, database);
 	setupControllers(bot);
 
+	await bot.api.setMyCommands([
+		{ command: "start", description: "About the bot" },
+		{ command: "download", description: "Download media from a replied link" },
+		{ command: "settings", description: "Configure captions and cleanup" },
+	]);
+
 	await bot.api.deleteWebhook();
 
 	return run(bot);

--- a/src/config/env.ts
+++ b/src/config/env.ts
@@ -15,6 +15,7 @@ export const APP_ENV = {
 	TOKEN: requireEnv("TOKEN"),
 	DB_CONNECTION_STRING: requireEnv("DB_CONNECTION_STRING"),
 	CACHE_CHAT_ID: requireEnv("CACHE_CHAT_ID"),
+	ADMIN_ID: optionalEnv("ADMIN_ID"),
 	WARP_PROXY: optionalEnv("WARP_PROXY"),
 	YT_DLP_PATH: Deno.env.get("YT_DLP_PATH") ?? "yt-dlp",
 	FFMPEG_PATH: Deno.env.get("FFMPEG_PATH") ?? "ffmpeg",

--- a/src/controllers/settings.ts
+++ b/src/controllers/settings.ts
@@ -1,8 +1,40 @@
 import { Composer } from "grammy";
 
-import { setChatCleanup } from "../services/chat.ts";
+import { APP_ENV } from "../config/env.ts";
+import { setChatSetting } from "../services/chat.ts";
 import type { CustomContext } from "../types/context.ts";
 import type { Settings } from "../types/database.ts";
+
+type SettingOption = {
+	key: keyof Settings;
+	labelKey: string;
+	adminOnly?: boolean;
+};
+
+const OPTIONS: Record<string, SettingOption> = {
+	cleanup: { key: "cleanup", labelKey: "option.cleanup" },
+	caption_reddit: { key: "captionReddit", labelKey: "option.captionReddit" },
+	caption_soundcloud: {
+		key: "captionSoundcloud",
+		labelKey: "option.captionSoundcloud",
+	},
+	caption_instagram: {
+		key: "captionInstagram",
+		labelKey: "option.captionInstagram",
+	},
+	caption_tiktok: { key: "captionTiktok", labelKey: "option.captionTiktok" },
+	caption_twitter: { key: "captionTwitter", labelKey: "option.captionTwitter" },
+	caption_youtube: { key: "captionYoutube", labelKey: "option.captionYoutube" },
+	caption_pinterest: {
+		key: "captionPinterest",
+		labelKey: "option.captionPinterest",
+	},
+	errors: { key: "errors", labelKey: "option.errors", adminOnly: true },
+};
+
+function isAdmin(userId: number | undefined) {
+	return APP_ENV.ADMIN_ID !== undefined && String(userId) === APP_ENV.ADMIN_ID;
+}
 
 export const settingsController = new Composer<CustomContext>();
 settingsController.command("settings", async (ctx) => {
@@ -15,37 +47,45 @@ settingsController.command("settings", async (ctx) => {
 		return;
 	}
 
-	// TODO: Refactor
-	const options: Record<keyof Settings, string> = {
-		cleanup: ctx.i18n.t("cleanupOption"),
-	};
+	const { settings } = ctx.objects.chat;
+	const enabled = ctx.i18n.t("enabled");
+	const disabled = ctx.i18n.t("disabled");
+	const adminHint = ctx.i18n.t("adminOnly");
 	const [option, value] = ctx.message.text.split(" ").slice(1) as [
-		(keyof Settings)?,
+		string?,
 		string?,
 	];
 
-	const enabled = ctx.i18n.t("enabled");
-	const disabled = ctx.i18n.t("disabled");
-
 	if (!option || !value) {
-		await ctx.text("settings", {
-			cleanupOption: options.cleanup,
-			cleanup: ctx.objects.chat.settings.cleanup ? enabled : disabled,
+		const lines = Object.entries(OPTIONS).map(([name, target]) => {
+			const state = settings[target.key] ? enabled : disabled;
+			const suffix = target.adminOnly ? ` · ${adminHint}` : "";
+			return `${state} ${ctx.i18n.t(target.labelKey)} (<code>${name}</code>)${suffix}`;
 		});
-	} else {
-		if (!options[option]) {
-			await ctx.text("unknownOption", { option });
-		} else {
-			const result = value === "yes" || value === "true";
-			await setChatCleanup({
-				db: ctx.db,
-				chatId: ctx.chat.id,
-				cleanup: result,
-			});
-			await ctx.text("settingsUpdated", {
-				option: options[option],
-				value: result ? enabled : disabled,
-			});
-		}
+		await ctx.text("settings", { options: lines.join("\n") });
+		return;
 	}
+
+	const target = OPTIONS[option];
+	if (!target) {
+		await ctx.text("unknownOption", { option });
+		return;
+	}
+
+	if (target.adminOnly && !isAdmin(ctx.from?.id)) {
+		await ctx.text("optionAdminOnly", { option: ctx.i18n.t(target.labelKey) });
+		return;
+	}
+
+	const result = value === "yes" || value === "true";
+	await setChatSetting({
+		db: ctx.db,
+		chatId: ctx.chat.id,
+		key: target.key,
+		value: result,
+	});
+	await ctx.text("settingsUpdated", {
+		option: ctx.i18n.t(target.labelKey),
+		value: result ? enabled : disabled,
+	});
 });

--- a/src/helpers/html.ts
+++ b/src/helpers/html.ts
@@ -1,0 +1,7 @@
+export function escapeHtml(value: string | number) {
+	return String(value)
+		.replaceAll("&", "&amp;")
+		.replaceAll("<", "&lt;")
+		.replaceAll(">", "&gt;")
+		.replaceAll('"', "&quot;");
+}

--- a/src/locales/en.json
+++ b/src/locales/en.json
@@ -25,6 +25,7 @@
 	},
 	"error": {
 		"viewOn": "${viewOn}\n\n<i>${error}</i>",
+		"report": "${viewOn}\n\n<i>Failed to download: ${error}</i>",
 		"audio": "😢 Failed to download audio",
 		"video": "😢 Failed to download video",
 		"image": "😢 Failed to download photo",
@@ -32,11 +33,31 @@
 		"videoSize": "🫨 Video is too big to download: ${size} Mb out of ${limit} Mb limit"
 	},
 	"promoCaption": "${viewUrl}",
+	"reasonNotice": "${viewOn}\n\n${reason}",
+	"reason": {
+		"ageRestricted": "🔞 This post is age-restricted (18+)",
+		"private": "🔒 This account is private",
+		"loginRequired": "🔒 This post requires a login to view",
+		"deleted": "🗑 This post was removed",
+		"notFound": "🗑 This post doesn't exist or was removed"
+	},
 	"settingsGroupOnly": "Settings are only available in group chats.",
-	"settings": "Chat settings:\n\n${cleanup} ${cleanupOption} (<code>cleanup</code>)\n\n/settings OPTION yes|no",
+	"settings": "Chat settings:\n\n${options}\n\n/settings OPTION yes|no",
+	"option": {
+		"cleanup": "Delete links",
+		"captionReddit": "Captions: Reddit",
+		"captionSoundcloud": "Captions: SoundCloud",
+		"captionInstagram": "Captions: Instagram",
+		"captionTiktok": "Captions: TikTok",
+		"captionTwitter": "Captions: Twitter",
+		"captionYoutube": "Captions: YouTube",
+		"captionPinterest": "Captions: Pinterest",
+		"errors": "Show errors"
+	},
 	"unknownOption": "Unknown option \"${option}\"\nSee /settings",
-	"cleanupOption": "Delete links",
 	"settingsUpdated": "\"${option}\" was set to \"${value}\"",
+	"optionAdminOnly": "\"${option}\" can only be changed by the admin.",
+	"adminOnly": "admin only",
 	"enabled": "🟢",
 	"disabled": "🔴"
 }

--- a/src/migrations/add-caption-settings.ts
+++ b/src/migrations/add-caption-settings.ts
@@ -1,0 +1,32 @@
+import { connectToDb } from "../config/database.ts";
+import { APP_ENV } from "../config/env.ts";
+import { DEFAULT_SETTINGS } from "../services/chat.ts";
+import type { Database } from "../types/database.ts";
+
+void APP_ENV;
+
+async function migrate(database: Database) {
+	await database.chat.updateMany(
+		{},
+		{
+			$set: {
+				"settings.captionReddit": DEFAULT_SETTINGS.captionReddit,
+				"settings.captionSoundcloud": DEFAULT_SETTINGS.captionSoundcloud,
+				"settings.captionInstagram": DEFAULT_SETTINGS.captionInstagram,
+				"settings.captionTiktok": DEFAULT_SETTINGS.captionTiktok,
+				"settings.captionTwitter": DEFAULT_SETTINGS.captionTwitter,
+				"settings.captionYoutube": DEFAULT_SETTINGS.captionYoutube,
+				"settings.captionPinterest": DEFAULT_SETTINGS.captionPinterest,
+				"settings.errors": DEFAULT_SETTINGS.errors,
+			},
+		},
+	);
+}
+
+console.info("Connecting…");
+const { database, client } = await connectToDb();
+console.info("Running migration…");
+await migrate(database);
+console.info("Disconnecting…");
+await client.close();
+console.info("Done");

--- a/src/migrations/add-chat-settings.ts
+++ b/src/migrations/add-chat-settings.ts
@@ -1,11 +1,12 @@
 import { connectToDb } from "../config/database.ts";
 import { APP_ENV } from "../config/env.ts";
+import { DEFAULT_SETTINGS } from "../services/chat.ts";
 import type { Database } from "../types/database.ts";
 
 void APP_ENV;
 
 async function migrate(database: Database) {
-	await database.chat.updateMany({}, { $set: { settings: { cleanup: true } } });
+	await database.chat.updateMany({}, { $set: { settings: DEFAULT_SETTINGS } });
 }
 
 console.info("Connecting…");

--- a/src/services/caption.ts
+++ b/src/services/caption.ts
@@ -1,0 +1,115 @@
+import { escapeHtml } from "../helpers/html.ts";
+import type { Settings } from "../types/database.ts";
+import type { SourceType } from "./sources.ts";
+
+// Normalized, transport-agnostic subset of postfetch metadata that the caption
+// renderer needs. Mapped from the library result at the resolver boundary so the
+// library's own types never leak deeper into the bot.
+export type PostCaptionMeta = {
+	title?: string;
+	text?: string;
+	authorHandle?: string;
+	authorName?: string;
+	likeCount?: number;
+	commentCount?: number;
+	subreddit?: string;
+};
+
+export type CaptionSetting = Extract<keyof Settings, `caption${string}`>;
+
+// Which chat setting toggles the caption for each source. Facebook has no
+// structured metadata, so it has no caption toggle.
+export const CAPTION_SETTING: Partial<Record<SourceType, CaptionSetting>> = {
+	reddit: "captionReddit",
+	soundcloud: "captionSoundcloud",
+	instagram: "captionInstagram",
+	tiktok: "captionTiktok",
+	twitter: "captionTwitter",
+	pinterest: "captionPinterest",
+	youtube: "captionYoutube",
+	youtubeVideo: "captionYoutube",
+};
+
+const MAX_TITLE_LENGTH = 256;
+// Telegram caption hard limit (visible characters); the rest of the budget is
+// reserved for the attribution line, facts, emoji fallbacks and newlines.
+const CAPTION_LIMIT = 1024;
+const RESERVE = 128;
+
+// Telegram custom emoji; the inner glyph is the fallback shown to non-premium users.
+const UPVOTE_EMOJI = '<tg-emoji emoji-id="5875078273775439450">🔼</tg-emoji>';
+const COMMENT_EMOJI = '<tg-emoji emoji-id="5994297722574737553">💬</tg-emoji>';
+
+export function captionEnabled(settings: Settings, sourceType: SourceType) {
+	const setting = CAPTION_SETTING[sourceType];
+	return setting ? settings[setting] : false;
+}
+
+// Renders an expandable Telegram blockquote that goes above the attribution line.
+// Reddit and SoundCloud get a structured header (title + facts); everyone else
+// quotes the post text (caption/tweet/description). Returns null when there is
+// nothing worth showing.
+export function buildPostCaption(
+	sourceType: SourceType,
+	meta: PostCaptionMeta,
+): string | null {
+	const body =
+		sourceType === "reddit"
+			? redditBody(meta)
+			: sourceType === "soundcloud"
+				? soundcloudBody(meta)
+				: textBody(meta);
+	return body ? `<blockquote expandable>${body}</blockquote>` : null;
+}
+
+function redditBody(meta: PostCaptionMeta): string | null {
+	if (!meta.title) {
+		return null;
+	}
+	const facts: string[] = [];
+	if (meta.subreddit) {
+		const sub = escapeHtml(meta.subreddit);
+		facts.push(`<a href="https://www.reddit.com/r/${sub}">r/${sub}</a>`);
+	}
+	if (meta.likeCount !== undefined) {
+		facts.push(`${UPVOTE_EMOJI} ${formatCount(meta.likeCount)}`);
+	}
+	if (meta.commentCount !== undefined) {
+		facts.push(`${COMMENT_EMOJI} ${formatCount(meta.commentCount)}`);
+	}
+	const title = truncate(meta.title, MAX_TITLE_LENGTH);
+	const head = [`<b>${escapeHtml(title)}</b>`, facts.join(" ")]
+		.filter(Boolean)
+		.join("\n");
+	const budget = CAPTION_LIMIT - RESERVE - title.length;
+	if (!meta.text || budget <= 0) {
+		return head;
+	}
+	return `${head}\n\n${escapeHtml(truncate(meta.text, budget))}`;
+}
+
+function soundcloudBody(meta: PostCaptionMeta): string | null {
+	if (!meta.title) {
+		return null;
+	}
+	const head = `<b>${escapeHtml(truncate(meta.title, MAX_TITLE_LENGTH))}</b>`;
+	const artist = meta.authorName ?? meta.authorHandle;
+	return artist ? `${head} — ${escapeHtml(artist)}` : head;
+}
+
+function textBody(meta: PostCaptionMeta): string | null {
+	return meta.text
+		? escapeHtml(truncate(meta.text, CAPTION_LIMIT - RESERVE))
+		: null;
+}
+
+function truncate(text: string, max: number): string {
+	const trimmed = text.trim();
+	return trimmed.length > max
+		? `${trimmed.slice(0, max - 1).trimEnd()}…`
+		: trimmed;
+}
+
+function formatCount(value: number): string {
+	return value.toLocaleString("en-US");
+}

--- a/src/services/chat.ts
+++ b/src/services/chat.ts
@@ -1,6 +1,18 @@
 import type { UpdateResult } from "mongodb";
 
-import type { Chat, Database } from "../types/database.ts";
+import type { Chat, Database, Settings } from "../types/database.ts";
+
+export const DEFAULT_SETTINGS: Settings = {
+	cleanup: true,
+	captionReddit: true,
+	captionSoundcloud: true,
+	captionInstagram: true,
+	captionTiktok: true,
+	captionTwitter: true,
+	captionYoutube: true,
+	captionPinterest: true,
+	errors: false,
+};
 
 async function createChat(args: {
 	db: Database;
@@ -10,9 +22,7 @@ async function createChat(args: {
 	const chatObject: Chat = {
 		chatId: args.chatId,
 		title: args.title,
-		settings: {
-			cleanup: true,
-		},
+		settings: { ...DEFAULT_SETTINGS },
 	};
 
 	await args.db.chat.insertOne(chatObject);
@@ -38,13 +48,14 @@ export async function getOrCreateChat(args: {
 	return createChat(args);
 }
 
-export function setChatCleanup(args: {
+export function setChatSetting(args: {
 	db: Database;
 	chatId: number;
-	cleanup: boolean;
+	key: keyof Settings;
+	value: boolean;
 }): Promise<UpdateResult> {
 	return args.db.chat.updateOne(
 		{ chatId: args.chatId },
-		{ $set: { "settings.cleanup": args.cleanup } },
+		{ $set: { [`settings.${args.key}`]: args.value } },
 	);
 }

--- a/src/services/download-media.ts
+++ b/src/services/download-media.ts
@@ -1,6 +1,7 @@
 import { InputFile } from "grammy";
 
-import type { DownloadMediaFile } from "./media.ts";
+import type { PostCaptionMeta } from "./caption.ts";
+import type { DownloadMediaFile, DownloadMediaResult } from "./media.ts";
 import { downloadWithPostfetch } from "./postfetch.ts";
 import { downloadWithYtdlp } from "./ytdlp.ts";
 
@@ -22,11 +23,13 @@ export type DownloadedMedia =
 			extension?: string;
 			filename?: string;
 			title?: string;
+			metadata?: PostCaptionMeta;
 	  }
 	| {
 			kind: "images";
 			files: DownloadedMediaGroupItem[];
 			images: DownloadedImage[];
+			metadata?: PostCaptionMeta;
 	  };
 
 function sanitizeFilename(filename: string) {
@@ -53,67 +56,102 @@ export async function materializeImageFiles(
 	return filenames;
 }
 
-export async function downloadMediaForUrl(
-	url: string,
-): Promise<DownloadedMedia | null> {
-	const media =
-		(await downloadWithPostfetch(url)) ?? (await downloadWithYtdlp(url));
-	if (media) {
+// Reads the typed unavailability cause that @postfetch/core attaches to its
+// errors; absent on resolvers (or older library versions) that do not set it.
+function postfetchReason(error: unknown): string | undefined {
+	if (error instanceof Error && "reason" in error) {
+		const value = (error as { reason?: unknown }).reason;
+		return typeof value === "string" ? value : undefined;
+	}
+	return undefined;
+}
+
+export async function downloadMediaForUrl(url: string): Promise<{
+	media: DownloadedMedia | null;
+	error?: string;
+	reason?: string;
+	metadata?: PostCaptionMeta;
+}> {
+	let error: string | undefined;
+	let reason: string | undefined;
+	for (const resolver of [downloadWithPostfetch, downloadWithYtdlp]) {
+		let result: DownloadMediaResult | null;
+		try {
+			result = await resolver(url);
+		} catch (caught) {
+			error ??= caught instanceof Error ? caught.message : String(caught);
+			reason ??= postfetchReason(caught);
+			continue;
+		}
+		if (!result) {
+			continue;
+		}
+		if (result.type === "text") {
+			console.info("[DownloadMedia] Resolved a text post", { url });
+			return { media: null, metadata: result.metadata };
+		}
 		console.info("[DownloadMedia] Downloaded media", {
 			url,
-			mediaType: media.type,
-			mediaKind: media.type === "single" ? media.mediaKind : "multiple",
+			mediaType: result.type,
+			mediaKind: result.type === "single" ? result.mediaKind : "multiple",
 		});
+		const media = toDownloadedMedia(result);
+		if (media) {
+			return { media };
+		}
+	}
 
-		if (media.type === "multiple") {
-			const files = media.files
-				.filter(
-					(
-						file,
-					): file is DownloadMediaFile & { mediaKind: "image" | "video" } =>
-						file.mediaKind === "image" || file.mediaKind === "video",
-				)
-				.map((file) => ({
-					kind: file.mediaKind,
-					file: new InputFile(file.data, file.filename),
-					media: file,
-				}));
+	console.info("[DownloadMedia] No resolver could download media", { url });
+	return { media: null, error, reason };
+}
 
-			if (files.length === 0) {
-				return null;
-			}
+function toDownloadedMedia(
+	result: Exclude<DownloadMediaResult, { type: "text" }>,
+): DownloadedMedia | null {
+	if (result.type === "multiple") {
+		const files = result.files
+			.filter(
+				(file): file is DownloadMediaFile & { mediaKind: "image" | "video" } =>
+					file.mediaKind === "image" || file.mediaKind === "video",
+			)
+			.map((file) => ({
+				kind: file.mediaKind,
+				file: new InputFile(file.data, file.filename),
+				media: file,
+			}));
 
-			if (files.length === 1) {
-				const [item] = files;
-				return {
-					kind: item.kind,
-					bytes: item.media.data,
-					extension: item.media.extension,
-					file: item.file,
-					filename: item.media.filename,
-				};
-			}
+		if (files.length === 0) {
+			return null;
+		}
 
+		if (files.length === 1) {
+			const [item] = files;
 			return {
-				kind: "images",
-				files,
-				images: files
-					.filter((item) => item.kind === "image")
-					.map((item) => item.media),
+				kind: item.kind,
+				bytes: item.media.data,
+				extension: item.media.extension,
+				file: item.file,
+				filename: item.media.filename,
+				metadata: result.metadata,
 			};
 		}
 
 		return {
-			kind: media.mediaKind,
-			bytes: media.file.data,
-			extension: media.extension,
-			file: new InputFile(media.file.data, media.file.filename),
-			filename: media.file.filename,
+			kind: "images",
+			files,
+			images: files
+				.filter((item) => item.kind === "image")
+				.map((item) => item.media),
+			metadata: result.metadata,
 		};
 	}
 
-	console.info("[DownloadMedia] No resolver could download media", {
-		url,
-	});
-	return null;
+	return {
+		kind: result.mediaKind,
+		bytes: result.file.data,
+		extension: result.extension,
+		file: new InputFile(result.file.data, result.file.filename),
+		filename: result.file.filename,
+		metadata: result.metadata,
+	};
 }

--- a/src/services/download-response.ts
+++ b/src/services/download-response.ts
@@ -1,5 +1,12 @@
 import { deletePaths } from "../helpers/fs.ts";
+import { escapeHtml } from "../helpers/html.ts";
 import type { CustomContext } from "../types/context.ts";
+import {
+	type PostCaptionMeta,
+	buildPostCaption,
+	captionEnabled,
+} from "./caption.ts";
+import { DEFAULT_SETTINGS } from "./chat.ts";
 import { type DownloadedMedia, downloadMediaForUrl } from "./download-media.ts";
 import type { SourceType } from "./sources.ts";
 
@@ -9,6 +16,9 @@ export type DownloadResponse = {
 	media: DownloadedMedia | null;
 	previewUrl: string;
 	text: string;
+	error?: string;
+	reason?: string;
+	metadata?: PostCaptionMeta;
 };
 
 type DownloadResponseData = {
@@ -20,14 +30,6 @@ type DownloadResponseData = {
 };
 
 type DownloadResponseMediaKind = NonNullable<DownloadResponse["media"]>["kind"];
-
-function escapeHtml(value: string | number) {
-	return String(value)
-		.replaceAll("&", "&amp;")
-		.replaceAll("<", "&lt;")
-		.replaceAll(">", "&gt;")
-		.replaceAll('"', "&quot;");
-}
 
 export function buildLinkPreviewOptions(url: string) {
 	return {
@@ -54,6 +56,22 @@ function getPromoText(
 }
 
 export function buildDownloadResponseText(
+	ctx: CustomContext,
+	data: DownloadResponseData,
+	mediaKind: DownloadResponseMediaKind | null,
+	title?: string,
+	meta?: PostCaptionMeta | null,
+) {
+	const base = buildBaseText(ctx, data, mediaKind, title);
+	const settings = ctx.objects?.chat?.settings ?? DEFAULT_SETTINGS;
+	if (!meta || !captionEnabled(settings, data.sourceType)) {
+		return base;
+	}
+	const quote = buildPostCaption(data.sourceType, meta);
+	return quote ? `${quote}\n${base}` : base;
+}
+
+function buildBaseText(
 	ctx: CustomContext,
 	data: DownloadResponseData,
 	mediaKind: DownloadResponseMediaKind | null,
@@ -105,7 +123,9 @@ export async function buildDownloadResponse(
 	};
 	const cleanup = async () => await deletePaths(tempDir ? [tempDir] : []);
 	const previewUrl = data.fallbackUrl ?? data.url;
-	const media = await downloadMediaForUrl(data.url);
+	const { media, error, reason, metadata } = await downloadMediaForUrl(
+		data.url,
+	);
 
 	if (!media) {
 		return {
@@ -113,7 +133,10 @@ export async function buildDownloadResponse(
 			getTempDir,
 			media: null,
 			previewUrl,
-			text: buildDownloadResponseText(ctx, data, null),
+			text: buildDownloadResponseText(ctx, data, null, undefined, metadata),
+			error,
+			reason,
+			metadata,
 		};
 	}
 
@@ -127,7 +150,13 @@ export async function buildDownloadResponse(
 			getTempDir,
 			media,
 			previewUrl,
-			text: buildDownloadResponseText(ctx, data, media.kind, title),
+			text: buildDownloadResponseText(
+				ctx,
+				data,
+				media.kind,
+				title,
+				media.metadata,
+			),
 		};
 	}
 
@@ -136,6 +165,12 @@ export async function buildDownloadResponse(
 		getTempDir,
 		media,
 		previewUrl,
-		text: buildDownloadResponseText(ctx, data, media.kind),
+		text: buildDownloadResponseText(
+			ctx,
+			data,
+			media.kind,
+			undefined,
+			media.metadata,
+		),
 	};
 }

--- a/src/services/media-file-cache.ts
+++ b/src/services/media-file-cache.ts
@@ -1,19 +1,25 @@
+import type { PostCaptionMeta } from "./caption.ts";
+
 export type CachedMedia =
 	| {
 			kind: "image";
 			fileId: string;
+			metadata?: PostCaptionMeta;
 	  }
 	| {
 			kind: "video";
 			fileId: string;
+			metadata?: PostCaptionMeta;
 	  }
 	| {
 			kind: "audio";
 			fileId: string;
+			metadata?: PostCaptionMeta;
 	  }
 	| {
 			kind: "images";
 			items: CachedMediaGroupItem[];
+			metadata?: PostCaptionMeta;
 	  };
 
 export type CachedMediaGroupItem = {

--- a/src/services/media.ts
+++ b/src/services/media.ts
@@ -1,14 +1,22 @@
+import type { PostCaptionMeta } from "./caption.ts";
+
 export type DownloadMediaResult =
 	| {
 			type: "single";
 			file: DownloadMediaFile;
 			mediaKind: "image" | "video" | "audio";
 			extension: string;
+			metadata?: PostCaptionMeta;
 	  }
 	| {
 			type: "multiple";
 			files: DownloadMediaFile[];
 			mediaKind: "mixed";
+			metadata?: PostCaptionMeta;
+	  }
+	| {
+			type: "text";
+			metadata?: PostCaptionMeta;
 	  };
 
 export type DownloadMediaFile = {

--- a/src/services/postfetch.ts
+++ b/src/services/postfetch.ts
@@ -1,5 +1,11 @@
-import { type MediaItem, download, postfetch } from "@postfetch/core";
+import {
+	type MediaItem,
+	type PostfetchResult,
+	download,
+	postfetch,
+} from "@postfetch/core";
 
+import type { PostCaptionMeta } from "./caption.ts";
 import {
 	type DownloadMediaFile,
 	type DownloadMediaResult,
@@ -20,14 +26,37 @@ export async function downloadWithPostfetch(
 			platform: result.platform,
 			fileCount: files.length,
 		});
-		return bundle(files);
+		const meta = toCaptionMeta(result);
+		const resolved = bundle(files);
+		return resolved
+			? { ...resolved, metadata: meta }
+			: { type: "text", metadata: meta };
 	} catch (error) {
 		console.warn("[Postfetch] Could not resolve", {
 			url,
 			error: error instanceof Error ? error.message : String(error),
 		});
-		return null;
+		throw error;
 	}
+}
+
+function toCaptionMeta(result: PostfetchResult): PostCaptionMeta | undefined {
+	const meta = result.metadata;
+	if (!meta) {
+		return undefined;
+	}
+	return {
+		title: meta.title,
+		text: meta.text,
+		authorHandle: meta.author?.handle,
+		authorName: meta.author?.name,
+		likeCount: meta.likeCount,
+		commentCount: meta.commentCount,
+		subreddit:
+			result.platform === "reddit"
+				? result.metadata?.extra?.subreddit
+				: undefined,
+	};
 }
 
 async function toDownloadMediaFile(

--- a/src/services/url-download.ts
+++ b/src/services/url-download.ts
@@ -1,6 +1,7 @@
 import { InputFile } from "grammy";
 import type { InputMediaPhoto, InputMediaVideo } from "grammy/types";
 
+import { escapeHtml } from "../helpers/html.ts";
 import type { CustomContext } from "../types/context.ts";
 import {
 	type CachedMedia as CachedChatMedia,
@@ -156,6 +157,62 @@ async function replyWithPreviewFallback(
 		link_preview_options: buildLinkPreviewOptions(result.previewUrl),
 	});
 	return true;
+}
+
+async function replyWithError(
+	ctx: CustomContext,
+	result: DownloadResponse,
+	replyExtra: ReturnType<typeof buildReplyExtra>,
+) {
+	const text = ctx.i18n.t("error.report", {
+		viewOn: result.text,
+		error: escapeHtml(result.error ?? "unknown error"),
+	});
+	await ctx.reply(text, {
+		parse_mode: "HTML",
+		...replyExtra,
+		link_preview_options: buildLinkPreviewOptions(result.previewUrl),
+	});
+}
+
+// Causes worth telling any user about (not a bug — a limitation of the post),
+// shown regardless of the admin-only error toggle.
+const USER_FACING_REASONS = new Set([
+	"ageRestricted",
+	"private",
+	"loginRequired",
+	"deleted",
+	"notFound",
+]);
+
+async function replyWithReason(
+	ctx: CustomContext,
+	result: DownloadResponse,
+	replyExtra: ReturnType<typeof buildReplyExtra>,
+) {
+	const text = ctx.i18n.t("reasonNotice", {
+		viewOn: result.text,
+		reason: ctx.i18n.t(`reason.${result.reason}`),
+	});
+	await ctx.reply(text, {
+		parse_mode: "HTML",
+		...replyExtra,
+		link_preview_options: buildLinkPreviewOptions(result.previewUrl),
+	});
+}
+
+// A text post (no media): the caption already holds title/body, so send it as a
+// plain message with the link preview off — the preview would just be noise.
+async function replyWithText(
+	ctx: CustomContext,
+	result: DownloadResponse,
+	replyExtra: ReturnType<typeof buildReplyExtra>,
+) {
+	await ctx.reply(result.text, {
+		parse_mode: "HTML",
+		...replyExtra,
+		link_preview_options: { is_disabled: true },
+	});
 }
 
 function buildGuestMediaMetadata(text: string): GuestMediaMetadata {
@@ -618,6 +675,8 @@ export async function downloadMatchedUrl(
 				ctx,
 				responseData,
 				cachedMedia.kind,
+				undefined,
+				cachedMedia.metadata,
 			);
 			if (ctx.guestMessage) {
 				const sent = await answerGuestQueryWithCachedMedia(
@@ -671,7 +730,15 @@ export async function downloadMatchedUrl(
 			}
 
 			if (!result.media) {
-				await replyWithPreviewFallback(ctx, result, replyExtra);
+				if (result.metadata) {
+					await replyWithText(ctx, result, replyExtra);
+				} else if (result.reason && USER_FACING_REASONS.has(result.reason)) {
+					await replyWithReason(ctx, result, replyExtra);
+				} else if (ctx.objects?.chat?.settings?.errors && result.error) {
+					await replyWithError(ctx, result, replyExtra);
+				} else {
+					await replyWithPreviewFallback(ctx, result, replyExtra);
+				}
 			} else if (result.media.kind === "images") {
 				const sentMessages = await replyWithMediaItems(
 					ctx,
@@ -684,7 +751,10 @@ export async function downloadMatchedUrl(
 				);
 				const cachedMedia = getCachedMediaFromMediaGroup(sentMessages);
 				if (cachedMedia) {
-					const normalizedUrl = setCachedMedia(url, cachedMedia);
+					const normalizedUrl = setCachedMedia(url, {
+						...cachedMedia,
+						metadata: result.media.metadata,
+					});
 					console.info("[Download] Cached media group file IDs", {
 						userId: ctx.from.id,
 						sourceType: type,
@@ -706,7 +776,10 @@ export async function downloadMatchedUrl(
 					sentMessage,
 				);
 				if (cachedMedia) {
-					const normalizedUrl = setCachedMedia(url, cachedMedia);
+					const normalizedUrl = setCachedMedia(url, {
+						...cachedMedia,
+						metadata: result.media.metadata,
+					});
 					console.info("[Download] Cached media file ID", {
 						userId: ctx.from.id,
 						sourceType: type,

--- a/src/services/ytdlp.ts
+++ b/src/services/ytdlp.ts
@@ -49,11 +49,9 @@ export async function downloadWithYtdlp(
 			stderr: "piped",
 		}).output();
 		if (!success) {
-			console.warn("[Ytdlp] Download failed", {
-				url,
-				error: new TextDecoder().decode(stderr).slice(0, 300),
-			});
-			return null;
+			const detail = new TextDecoder().decode(stderr).slice(0, 300).trim();
+			console.warn("[Ytdlp] Download failed", { url, error: detail });
+			throw new Error(detail || "yt-dlp download failed");
 		}
 		const files = await readDownloadedFiles(directory);
 		console.info("[Ytdlp] Downloaded media", { url, fileCount: files.length });
@@ -63,7 +61,7 @@ export async function downloadWithYtdlp(
 			url,
 			error: error instanceof Error ? error.message : String(error),
 		});
-		return null;
+		throw error;
 	} finally {
 		await Deno.remove(directory, { recursive: true }).catch(() => undefined);
 	}

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -2,6 +2,14 @@ import type { Collection } from "mongodb";
 
 export type Settings = {
 	cleanup: boolean;
+	captionReddit: boolean;
+	captionSoundcloud: boolean;
+	captionInstagram: boolean;
+	captionTiktok: boolean;
+	captionTwitter: boolean;
+	captionYoutube: boolean;
+	captionPinterest: boolean;
+	errors: boolean;
 };
 
 export type Chat = {

--- a/test/caption.test.ts
+++ b/test/caption.test.ts
@@ -1,0 +1,73 @@
+import { assert, assertEquals } from "jsr:@std/assert@^1";
+
+import { buildPostCaption, captionEnabled } from "../src/services/caption.ts";
+import type { Settings } from "../src/types/database.ts";
+
+const settings: Settings = {
+	cleanup: true,
+	captionReddit: true,
+	captionSoundcloud: true,
+	captionInstagram: false,
+	captionTiktok: false,
+	captionTwitter: false,
+	captionYoutube: false,
+	captionPinterest: false,
+	errors: false,
+};
+
+Deno.test("reddit caption shows title and a facts line", () => {
+	const caption = buildPostCaption("reddit", {
+		title: "Seen in the UK",
+		subreddit: "pics",
+		authorHandle: "Gertrudethecurious",
+		likeCount: 9969,
+		commentCount: 251,
+	});
+	assertEquals(
+		caption,
+		'<blockquote expandable><b>Seen in the UK</b>\n<a href="https://www.reddit.com/r/pics">r/pics</a> <tg-emoji emoji-id="5875078273775439450">🔼</tg-emoji> 9,969 <tg-emoji emoji-id="5994297722574737553">💬</tg-emoji> 251</blockquote>',
+	);
+});
+
+Deno.test("reddit caption is null without a title", () => {
+	assertEquals(buildPostCaption("reddit", { likeCount: 5 }), null);
+});
+
+Deno.test("soundcloud caption shows track and artist", () => {
+	const caption = buildPostCaption("soundcloud", {
+		title: "Không Buông",
+		authorName: "Hngle",
+	});
+	assertEquals(
+		caption,
+		"<blockquote expandable><b>Không Buông</b> — Hngle</blockquote>",
+	);
+});
+
+Deno.test("text platforms quote the post text and escape HTML", () => {
+	const caption = buildPostCaption("tiktok", {
+		text: 'hello <b>world</b> & "more"',
+	});
+	assertEquals(
+		caption,
+		"<blockquote expandable>hello &lt;b&gt;world&lt;/b&gt; &amp; &quot;more&quot;</blockquote>",
+	);
+});
+
+Deno.test("text platforms without text yield no caption", () => {
+	assertEquals(buildPostCaption("twitter", { likeCount: 3 }), null);
+});
+
+Deno.test("long text is truncated with an ellipsis", () => {
+	const caption = buildPostCaption("instagram", { text: "a".repeat(2000) });
+	assert(caption !== null);
+	assert(caption.endsWith("…</blockquote>"));
+	assert(caption.length < 1000);
+});
+
+Deno.test("captionEnabled follows per-platform settings", () => {
+	assertEquals(captionEnabled(settings, "reddit"), true);
+	assertEquals(captionEnabled(settings, "tiktok"), false);
+	assertEquals(captionEnabled(settings, "facebook"), false);
+	assertEquals(captionEnabled(settings, "youtubeVideo"), false);
+});

--- a/test/live.test.ts
+++ b/test/live.test.ts
@@ -13,7 +13,7 @@ async function downloads(
 	url: string,
 	kind: "image" | "video" | "audio" | "images",
 ): Promise<void> {
-	const media = await downloadMediaForUrl(url);
+	const { media } = await downloadMediaForUrl(url);
 	assert(media !== null, `no media resolved for ${url}`);
 	assert(media.kind === kind, `expected ${kind}, got ${media.kind} for ${url}`);
 	const bytes =


### PR DESCRIPTION
Builds on `@postfetch/core` 0.5.0 metadata.

- **Captions**: expandable blockquote above the attribution — Reddit/SoundCloud get a structured header (title + `r/sub`/artist + reactions), others quote the post text. Cached so they survive cache hits.
- **Text posts** (no media) are sent as text with the link preview off.
- **/settings**: per-platform caption toggles + admin-only `errors` toggle (raw resolver error dump). Generalized the settings controller; migration for existing chats.
- **Reasons**: user-facing `ageRestricted`/`private`/`loginRequired`/`deleted`/`notFound` shown always; technical errors only under the `errors` toggle.
- `setMyCommands` on startup.