### PR TITLE
🔧 Bump @postfetch/core to 0.5.1

### DIFF
--- a/deno.json
+++ b/deno.json
@@ -16,7 +16,7 @@
 		"@grammyjs/auto-retry": "npm:@grammyjs/auto-retry@2.0.2",
 		"@grammyjs/i18n": "npm:@grammyjs/i18n@0.5.1",
 		"@grammyjs/runner": "npm:@grammyjs/runner@2.0.3",
-		"@postfetch/core": "jsr:@postfetch/core@^0.5.0",
+		"@postfetch/core": "jsr:@postfetch/core@^0.5.1",
 		"grammy": "npm:grammy@1.43.0",
 		"mongodb": "npm:mongodb@4.17.2"
 	}

--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@postfetch/core@0.5": "0.5.0",
+    "jsr:@postfetch/core@~0.5.1": "0.5.1",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "npm:@biomejs/biome@1.9.4": "1.9.4",
@@ -12,8 +12,8 @@
     "npm:mongodb@4.17.2": "4.17.2"
   },
   "jsr": {
-    "@postfetch/core@0.5.0": {
-      "integrity": "24b7d776199f39e1ffdaa8b7c744ac4c3c52b8c0624d49a22bdecbc7e9333e13"
+    "@postfetch/core@0.5.1": {
+      "integrity": "dd546d7db40be01e540134fb51c6f0ddbaf68ede91af61c542e2f7403d083fc6"
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -1097,7 +1097,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@postfetch/core@0.5",
+      "jsr:@postfetch/core@~0.5.1",
       "npm:@biomejs/biome@1.9.4",
       "npm:@grammyjs/auto-retry@2.0.2",
       "npm:@grammyjs/i18n@0.5.1",


### PR DESCRIPTION
Picks up TikTok `/photo/<id>` slideshow support (the lock still pinned 0.5.0).