### PR TITLE
🔧 Bump @postfetch/core to 0.5.2 + fix flaky WARP CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,22 +37,34 @@ jobs:
           sudo curl -fsSL https://github.com/yt-dlp/yt-dlp/releases/latest/download/yt-dlp -o /usr/local/bin/yt-dlp
           sudo chmod a+rx /usr/local/bin/yt-dlp
 
-      - name: Start the WARP sidecar
+      - name: Start the WARP sidecar (only where the runner IP is gated)
         run: |
+          # Only YouTube and TikTok gate the datacenter runner IP, so only they
+          # need WARP. It is best-effort: probes are time-boxed so a dead tunnel
+          # never hangs the job, and WARP_PROXY is exported only once warp=on is
+          # confirmed — otherwise the download falls back to the runner IP.
+          case "${{ matrix.platform }}" in
+            youtube | tiktok) ;;
+            *) echo "WARP not needed for ${{ matrix.platform }}"; exit 0 ;;
+          esac
           docker build -t umm-warp warp
           docker run -d --name umm-warp -p 1080:1080 umm-warp
-          for _ in $(seq 1 30); do
-            curl -fsS -x socks5h://127.0.0.1:1080 https://www.cloudflare.com/cdn-cgi/trace 2>/dev/null | grep -q 'warp=on' && break
-            sleep 2
+          up=""
+          for _ in $(seq 1 20); do
+            if curl -fsS --connect-timeout 3 --max-time 5 -x socks5h://127.0.0.1:1080 https://www.cloudflare.com/cdn-cgi/trace 2>/dev/null | grep -q 'warp=on'; then
+              echo "WARP_PROXY=socks5://127.0.0.1:1080" >> "$GITHUB_ENV"
+              up=1
+              echo "WARP is up"
+              break
+            fi
+            sleep 1
           done
-          echo "host IP: $(curl -s https://api.ipify.org)"
-          curl -s -x socks5h://127.0.0.1:1080 https://www.cloudflare.com/cdn-cgi/trace | grep -E '^(ip|warp)='
+          [ -n "$up" ] || echo "WARP did not come up; resolving on the runner IP"
 
       - name: Download ${{ matrix.platform }} through WARP
         env:
           UMM_LIVE: "1"
           UMM_LIVE_PLATFORM: ${{ matrix.platform }}
-          WARP_PROXY: socks5://127.0.0.1:1080
           TOKEN: ci
           DB_CONNECTION_STRING: ci
           CACHE_CHAT_ID: ci

--- a/deno.json
+++ b/deno.json
@@ -16,7 +16,7 @@
 		"@grammyjs/auto-retry": "npm:@grammyjs/auto-retry@2.0.2",
 		"@grammyjs/i18n": "npm:@grammyjs/i18n@0.5.1",
 		"@grammyjs/runner": "npm:@grammyjs/runner@2.0.3",
-		"@postfetch/core": "jsr:@postfetch/core@^0.5.1",
+		"@postfetch/core": "jsr:@postfetch/core@^0.5.2",
 		"grammy": "npm:grammy@1.43.0",
 		"mongodb": "npm:mongodb@4.17.2"
 	}

--- a/deno.lock
+++ b/deno.lock
@@ -1,7 +1,7 @@
 {
   "version": "5",
   "specifiers": {
-    "jsr:@postfetch/core@~0.5.1": "0.5.1",
+    "jsr:@postfetch/core@~0.5.2": "0.5.2",
     "jsr:@std/assert@1": "1.0.19",
     "jsr:@std/internal@^1.0.12": "1.0.12",
     "npm:@biomejs/biome@1.9.4": "1.9.4",
@@ -12,8 +12,8 @@
     "npm:mongodb@4.17.2": "4.17.2"
   },
   "jsr": {
-    "@postfetch/core@0.5.1": {
-      "integrity": "dd546d7db40be01e540134fb51c6f0ddbaf68ede91af61c542e2f7403d083fc6"
+    "@postfetch/core@0.5.2": {
+      "integrity": "9ca6faf9ec1f8290eea9388affbf1d15a56bbe10053fe353826bd68bb0294666"
     },
     "@std/assert@1.0.19": {
       "integrity": "eaada96ee120cb980bc47e040f82814d786fe8162ecc53c91d8df60b8755991e",
@@ -1097,7 +1097,7 @@
   },
   "workspace": {
     "dependencies": [
-      "jsr:@postfetch/core@~0.5.1",
+      "jsr:@postfetch/core@~0.5.2",
       "npm:@biomejs/biome@1.9.4",
       "npm:@grammyjs/auto-retry@2.0.2",
       "npm:@grammyjs/i18n@0.5.1",


### PR DESCRIPTION
- Bump `@postfetch/core` → 0.5.2 (Facebook reel support with author/view metadata).
- Fix the live WARP CI: the readiness curl had no timeout, so a runner that couldn't establish the tunnel hung ~20 min then failed the job (soundcloud/youtube). Now WARP is scoped to youtube/tiktok, probes are time-boxed, and it falls back to the runner IP instead of failing.